### PR TITLE
fix: Stop game after player death

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,11 @@ def start():
     game_state = create_game_state(player)
 
     play_story(story, game_state)
+
+    if game_state['player'].health <= 0:
+        slow_print("\nYour adventure ends here. Thanks for playing!")
+        return
+    
     event = consume_event(game_state)
     if event:
         slow_print(f"\nAn {game_state['active_monster']} appears!")

--- a/src/story_navigators.py
+++ b/src/story_navigators.py
@@ -28,7 +28,6 @@ def play_story(story: dict, game_state: dict) -> bool | None:
         scene = story[current_scene]
         choice = handle_choice(scene)
 
-        # scene zonder keuzes (zoals battle_start)
         if not scene.get("options"):
            if scene.get("monster"):
                 game_state['active_monster'] = monster.Monster(
@@ -37,11 +36,14 @@ def play_story(story: dict, game_state: dict) -> bool | None:
                     loot=scene["monster"]["loot"]
                 )
                 trigger_event(game_state)
+            
+                if game_state['player'].health <= 0:
+                    return False
+           
            next_scene = scene.get("next")
            current_scene = next_scene if next_scene else None
            continue
 
-        # geen volgende scene = stop
         if "next" not in scene or not scene["next"]:
             return 
 


### PR DESCRIPTION
The game kept going after the player's health dropped to 0 or below, which was not the intended behavior. This commit adds checks to stop the game when the player dies, both in the main game loop and after combat encounters. Now, if the player's health reaches 0 or less, a message is displayed and the game ends gracefully.